### PR TITLE
introduce package_ensure paramter

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'adamstrawson-byobu'
-version '0.0.1'
+version '0.1.0'
 summary "Puppet Module: Byobu"
 description "The Byobu module installs byobu"
 project_page "https://github.com/adamstrawson/puppet-byobu"

--- a/README.markdown
+++ b/README.markdown
@@ -8,13 +8,33 @@ Overview
 The Byobu module installs byobu [https://launchpad.net/byobu](https://launchpad.net/byobu)
 
 Limitations
-------------
+-----------
 
-This module has been built and tested using Puppet 2.7.
+This module has been built and tested using Puppet 2.7 and Puppet 3.4.x
 
 The module has been tested on:
 
-* Debian 6.0 
+* Debian 6.0
 * Ubuntu 12.04
 
 If you have it working on other envrioments, please submit a pull request.
+
+Parameters
+----------
+
+*`package_ensure`* Ensure the package is installed in a specific *version*, or *latest*, or *absent*.
+Default: *present*
+
+Example
+-------
+
+Install byobu:
+```puppet
+    include 'byobu'
+```
+Install a specific version of byobu:
+```puppet
+    class { 'byobu':
+	    package_ensure => '1.4.3',
+    }
+```

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,8 +11,10 @@
 #   Actions:
 #    Installs byobu.
 
-class byobu {
+class byobu (
+  $package_ensure = 'present'
+){
     package { 'byobu':
-        ensure => latest,
+        ensure => $package_ensure,
     }
 }


### PR DESCRIPTION
following the puppet module style guide, we introduce a package_ensure
parameter for this class and set it to default to 'present'. This is a
break to the current behaviour, but again, a recommended standard. Non
the less, we bump the version, to mark this change.
